### PR TITLE
feat: add creation static svg-element

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,13 +8,18 @@ import { Element } from './types/Common';
 const App = () => {
   const [elements, setElements] = useState<Element[]>([]);
 
-  const hendleCreateElement = (value: Element) => {
-    setElements((prev) => [...prev, value]);
+  const handleCreateElement = (value: Element) => {
+    setElements((prev) => {
+      // uuid = latest/biger prev id +1
+      const uuid =
+        prev.length > 0 ? (+prev[prev.length - 1].id + 1).toString() : '1';
+      return [...prev, { ...value, id: uuid }];
+    });
   };
 
   return (
     <div className="flex flex-col h-screen relative">
-      <Toolbar create={hendleCreateElement} />
+      <Toolbar onCreate={handleCreateElement} />
       <Canvas elements={elements} />
       <Inspector />
       <Layers />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,12 +9,7 @@ const App = () => {
   const [elements, setElements] = useState<Element[]>([]);
 
   const handleCreateElement = (value: Element) => {
-    setElements((prev) => {
-      // uuid = latest/biger prev id +1
-      const uuid =
-        prev.length > 0 ? (+prev[prev.length - 1].id + 1).toString() : '1';
-      return [...prev, { ...value, id: uuid }];
-    });
+    setElements((prev) => [...prev, { ...value, id: crypto.randomUUID() }]);
   };
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,21 @@
+import { useState } from 'react';
 import Canvas from './components/Canvas';
 import Inspector from './components/Inspector';
 import Layers from './components/Layers';
 import Toolbar from './components/Toolbar';
+import { Element } from './types/Common';
 
 const App = () => {
+  const [elements, setElements] = useState<Element[]>([]);
+
+  const hendleCreateElement = (value: Element) => {
+    setElements((prev) => [...prev, value]);
+  };
+
   return (
     <div className="flex flex-col h-screen relative">
-      <Toolbar />
-      <Canvas />
+      <Toolbar create={hendleCreateElement} />
+      <Canvas elements={elements} />
       <Inspector />
       <Layers />
     </div>

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -14,16 +14,10 @@ const Canvas = ({ elements }: Props) => {
       height="100%"
       xmlns="http://www.w3.org/2000/svg"
     >
-      {elements.map((block, i) => (
+      {elements.map((block) => (
         <block.type //flexible&dynemic rendering svg-elements
-          key={i}
-          x={block.x}
-          y={block.y}
-          width={block.width}
-          height={block.height}
-          stroke={block.stroke}
-          strokeWidth={block.strokeWidth}
-          fill={block.fill}
+          key={block.id}
+          {...block}
         />
       ))}
     </svg>

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,9 +1,32 @@
-const Canvas = () => {
+import { Element } from '../types/Common';
+
+interface Props {
+  elements: Element[];
+}
+
+const Canvas = ({ elements }: Props) => {
   return (
-    <main className="border border-red-700 h-full">
-      Canvas
-      <svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"></svg>
-    </main>
+    <svg
+      className="border-4 border-green-600"
+      preserveAspectRatio="xMinYMin meet" //for the SVG container to be on the entire screen, while the elements inside kept the proportions and x=0, y=0 viewBox started from the upper left corner
+      viewBox="0 0 1920 1080"
+      width="100%"
+      height="100%"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {elements.map((block, i) => (
+        <block.type //flexible&dynemic rendering svg-elements
+          key={i}
+          x={block.x}
+          y={block.y}
+          width={block.width}
+          height={block.height}
+          stroke={block.stroke}
+          strokeWidth={block.strokeWidth}
+          fill={block.fill}
+        />
+      ))}
+    </svg>
   );
 };
 

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -1,6 +1,6 @@
 const Inspector = () => {
   return (
-    <aside className="absolute min-w-[10%] max-w-[25%] max-h-[80%] overflow-auto px-3 py-5  top-[10%] right-5 border border-black">
+    <aside className="fixed min-w-[10%] max-w-[25%] max-h-[80%] overflow-auto px-3 py-5  top-[10%] right-5 border border-black">
       Inspector
     </aside>
   );

--- a/src/components/Layers.tsx
+++ b/src/components/Layers.tsx
@@ -1,6 +1,6 @@
 const Layers = () => {
   return (
-    <aside className="absolute min-w-[10%] max-w-[20%] max-h-[80%] overflow-auto px-3 py-5 top-[10%] left-5 border border-green-700">
+    <aside className="fixed min-w-[10%] max-w-[20%] max-h-[80%] overflow-auto px-3 py-5 top-[10%] left-5 border border-green-700">
       Layers
     </aside>
   );

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,7 +1,39 @@
-const Toolbar = () => {
+import { Element } from '../types/Common';
+
+interface Props {
+  create: (value: Element) => void;
+}
+
+const emptyElement = {
+  x: 0,
+  y: 0,
+  width: 240,
+  height: 300,
+  stroke: 'black',
+  strokeWidth: 2,
+  fill: 'none',
+};
+
+const Toolbar = ({ create }: Props) => {
   return (
-    <header className="h-10 flex justify-center gap-4 border border-black">
-      <button className="border border-blue-700">rect</button>
+    <header className="h-[6%] sticky top-0 flex justify-center gap-4 border-4 border-black">
+      <button onClick={() => create({ ...emptyElement, type: 'rect' })}>
+        <svg
+          viewBox="0 0 24 24"
+          height="50%"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            x="0"
+            y="0"
+            width="100%"
+            height="100%"
+            stroke="black"
+            strokeWidth="2"
+            fill="none"
+          />
+        </svg>
+      </button>
       <button className="border border-blue-700">elips</button>
       <button className="border border-blue-700">line</button>
     </header>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -5,7 +5,7 @@ interface Props {
 }
 
 const emptyElement = {
-  id: '0',
+  id: '',
   x: 0,
   y: 0,
   width: 240,

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,10 +1,11 @@
 import { Element } from '../types/Common';
 
 interface Props {
-  create: (value: Element) => void;
+  onCreate: (value: Element) => void;
 }
 
 const emptyElement = {
+  id: '0',
   x: 0,
   y: 0,
   width: 240,
@@ -14,10 +15,10 @@ const emptyElement = {
   fill: 'none',
 };
 
-const Toolbar = ({ create }: Props) => {
+const Toolbar = ({ onCreate }: Props) => {
   return (
     <header className="h-[6%] sticky top-0 flex justify-center gap-4 border-4 border-black">
-      <button onClick={() => create({ ...emptyElement, type: 'rect' })}>
+      <button onClick={() => onCreate({ ...emptyElement, type: 'rect' })}>
         <svg
           viewBox="0 0 24 24"
           height="50%"

--- a/src/types/Common.ts
+++ b/src/types/Common.ts
@@ -1,0 +1,10 @@
+export interface Element {
+  type: "rect" | "circle" | "line";
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  stroke?: string;
+  strokeWidth?: number;
+  fill?: string;
+}

--- a/src/types/Common.ts
+++ b/src/types/Common.ts
@@ -1,4 +1,5 @@
 export interface Element {
+  id: string;
   type: "rect" | "circle" | "line";
   x?: number;
   y?: number;


### PR DESCRIPTION
fix #4 
-[] add Fn creation static svg-el different/dinemic types by clicking on it in toolbar;
-[] made an svg container to the whole screen, while maintaining the proportions of the child elements and x=0 y=0 correspond to the upper left corner.

![image](https://github.com/KirillSerg/drawler/assets/99827460/ce245ed2-e51c-4a33-8713-e91434d01069)

