### PR TITLE
feat: create connections(sticking) of lines with elements

### DIFF
--- a/src/assets/utilities.ts
+++ b/src/assets/utilities.ts
@@ -270,3 +270,52 @@ export const getBorderRadius = (width: number, height: number, percent: number =
 export const colorsPalette = [
   "transparent", "black", "white", "gray", "brown", "cyan", "blue", "violet", "#be4bdb", "pink", "green", "teal", "yellow", "orange", "red"
 ]
+
+export const getConnect = (line: Element, allelements: Element[]) => {
+  let connectByStartTo: Element | null = null
+  let connectByEndTo: Element | null = null
+  const elementsToConnect: Element["connectedlines"] = []
+  const elementsToDisconnect: Element[] = []
+
+  // loop in the reverse direction to connect to the last element (higher in layers)
+  for (let i = allelements.length - 1; i >= 0; i--) {
+    if (
+      line.id !== allelements[i].id &&
+      !connectByStartTo &&
+      line.x1 >= allelements[i].x &&
+      line.y1 >= allelements[i].y &&
+      line.x1 <= allelements[i].x + allelements[i].width &&
+      line.y1 <= allelements[i].y + allelements[i].height
+    ) {
+      connectByStartTo = allelements[i]
+    } else if (allelements[i].connectedlines.find((connect) => connect.element.id === line.id && connect.byStart)) {
+      elementsToDisconnect.push(allelements[i])
+    }
+    if (
+      line.id !== allelements[i].id &&
+      !connectByEndTo &&
+      line.x2 >= allelements[i].x &&
+      line.y2 >= allelements[i].y &&
+      line.x2 <= allelements[i].x + allelements[i].width &&
+      line.y2 <= allelements[i].y + allelements[i].height
+    ) {
+      connectByEndTo = allelements[i]
+    } else if (allelements[i].connectedlines.find((connect) => connect.element.id === line.id && connect.byEnd)) {
+      elementsToDisconnect.push(allelements[i])
+    }
+  }
+
+  if (connectByStartTo && connectByEndTo && connectByStartTo?.id === connectByEndTo?.id) {
+    return { elementsToConnect: [{ element: connectByStartTo, byStart: true, byEnd: true }], elementsToDisconnect }
+  }
+
+  if (connectByStartTo) {
+    elementsToConnect.push({ element: connectByStartTo, byStart: true, byEnd: false })
+  }
+  if (connectByEndTo) {
+    elementsToConnect.push({ element: connectByEndTo, byStart: false, byEnd: true })
+  }
+
+  return ({ elementsToConnect, elementsToDisconnect })
+}
+

--- a/src/components/singleElement/SelectingFrame.tsx
+++ b/src/components/singleElement/SelectingFrame.tsx
@@ -81,7 +81,7 @@ const SelectingFrame = ({ element }: Props) => {
               className="hover:cursor-nesw-resize"
               onMouseDown={() => setResizeVector('nordeast')}
               onMouseUp={onMouseUp}
-              x={element.x + element.width - element.strokeWidth / 2 + 7}
+              x={element.x + element.width - element.strokeWidth / 2 + 1}
               y={element.y - element.strokeWidth / 2 - 7}
               width="10"
               height="10"
@@ -94,8 +94,8 @@ const SelectingFrame = ({ element }: Props) => {
               className="hover:cursor-nwse-resize"
               onMouseDown={() => setResizeVector('southeast')}
               onMouseUp={onMouseUp}
-              x={element.x + element.width - element.strokeWidth / 2 + 7}
-              y={element.y + element.height - element.strokeWidth / 2 + 7}
+              x={element.x + element.width - element.strokeWidth / 2 + 1}
+              y={element.y + element.height - element.strokeWidth / 2 + 1}
               width="10"
               height="10"
               stroke="blue"
@@ -108,7 +108,7 @@ const SelectingFrame = ({ element }: Props) => {
               onMouseDown={() => setResizeVector('southwest')}
               onMouseUp={onMouseUp}
               x={element.x - element.strokeWidth / 2 - 7}
-              y={element.y + element.height - element.strokeWidth / 2 + 7}
+              y={element.y + element.height - element.strokeWidth / 2 + 1}
               width="10"
               height="10"
               stroke="blue"

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -26,6 +26,11 @@ export interface Element {
   fill: string;
   fontSize: string;
   opacity: string;
+  connectedlines: {
+    element: Element;
+    byStart: boolean;
+    byEnd: boolean;
+  }[]
 }
 
 export interface ElementProps {


### PR DESCRIPTION
resolve #51 
create connections(sticking) of lines with elements. So when line in area of element, and user drag this element, the line (connected point - start or end of line) dragging to.
![line-connecting-_18-Sep-24-14-13-42_](https://github.com/user-attachments/assets/eba2a1fc-6154-46af-9640-2d236b075bbc)
